### PR TITLE
 Fixed is_authenticated()

### DIFF
--- a/tastypie_oauth/authentication.py
+++ b/tastypie_oauth/authentication.py
@@ -63,7 +63,7 @@ class OAuth20Authentication(Authentication):
 
             # If OAuth authentication is successful, set the request user to
             # the token user for authorization
-            request.user = token.user
+            request.user = token.user or AnonymousUser()
 
             # If OAuth authentication is successful, set oauth_consumer_key on
             # request in case we need it later

--- a/tastypie_oauth/authentication.py
+++ b/tastypie_oauth/authentication.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone
 from tastypie.authentication import Authentication
-from tastypie.http import HttpUnauthorized
 
 """
 This is a simple OAuth 2.0 authentication model for tastypie


### PR DESCRIPTION
Error: 'NoneType' object has no attribute 'has_perm'.

It happens when a 'client_credentials' is used to POST a resource URL.
