### PR TITLE
Upgraded django-oauth-toolkit to 0.9 in requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django_tastypie>=0.9.16,<0.13
-django-oauth-toolkit>=0.7,<0.8
+django-oauth-toolkit>=0.7,<=0.9
 python-mimeparse>=0.1,<0.2
 # or
 # django-oauth2-provider>=0.2,<0.3


### PR DESCRIPTION
We are actually using django-oauth-toolkit with 0.9 in our production environment without any problems.
