### PR TITLE
Fixing oauth_consumer_key nor being part of message

### DIFF
--- a/tastypie_oauth/authentication.py
+++ b/tastypie_oauth/authentication.py
@@ -78,6 +78,8 @@ class OAuth20Authentication(Authentication):
             log.exception("Error in OAuth20Authentication.")
             request.user = AnonymousUser()
             return False
+        except OAuthError:
+            return False
         except Exception:
             log.exception("Error in OAuth20Authentication.")
             return False

--- a/tastypie_oauth/authentication.py
+++ b/tastypie_oauth/authentication.py
@@ -54,7 +54,10 @@ class OAuth20Authentication(Authentication):
             if not key and request.method == 'POST':
                 if request.META.get('CONTENT_TYPE') == 'application/json':
                     decoded_body = request.body.decode('utf8')
-                    key = json.loads(decoded_body)['oauth_consumer_key']
+                    try:
+                        key = json.loads(decoded_body)['oauth_consumer_key']
+                    except (ValueError, KeyError):
+                        pass
             if not key:
                 log.info('OAuth20Authentication. No consumer_key found.')
                 return None


### PR DESCRIPTION
Fixes if the provided content is no valid json or oauth_consumer_key not being part of the message.